### PR TITLE
Document generics in responses correctly

### DIFF
--- a/src/test/java/com/wordnik/jaxrs/PetResource.java
+++ b/src/test/java/com/wordnik/jaxrs/PetResource.java
@@ -32,7 +32,6 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import io.swagger.annotations.Extension;
 import io.swagger.annotations.ExtensionProperty;
-
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -46,6 +45,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 @Path("/pet")
 @Api(value = "/pet", description = "Operations about pets", authorizations = {
@@ -305,10 +305,10 @@ public class PetResource {
     }
 
     @ApiOperation(value = "testingArrayResponse")
-    @ApiResponses(@ApiResponse(code = 200, message = "array", response = Pet.class, responseContainer = "List"))
+    @ApiResponses(@ApiResponse(code = 200, message = "array"))
     @GET
     @Path("/test/testingArrayResponse")
-    public Response testingArrayResponse() {
+    public List<Pet> testingArrayResponse() {
         return null;
     }
 

--- a/src/test/java/com/wordnik/jaxrs/UserResource.java
+++ b/src/test/java/com/wordnik/jaxrs/UserResource.java
@@ -29,7 +29,6 @@ import io.swagger.annotations.Contact;
 import io.swagger.annotations.Info;
 import io.swagger.annotations.License;
 import io.swagger.annotations.SwaggerDefinition;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -50,11 +49,10 @@ import javax.ws.rs.core.Response;
                 termsOfService = "http://www.github.com/kongchen/swagger-maven-plugin",
                 contact = @Contact(name = "Kong Chen", email = "kongchen@gmail.com", url = "http://kongch.com"),
                 license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html")
-        )
-)
+        ))
 @Path("/user")
 @Api(value = "/user", description = "Operations about user")
-@Produces({"application/json", "application/xml"})
+@Produces({ "application/json", "application/xml" })
 public class UserResource {
     static UserData userData = new UserData();
 
@@ -97,7 +95,7 @@ public class UserResource {
             position = 4)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid user supplied"),
-            @ApiResponse(code = 404, message = "User not found")})
+            @ApiResponse(code = 404, message = "User not found") })
     public Response updateUser(
             @ApiParam(value = "name that need to be deleted", required = true) @PathParam("username") String username,
             @ApiParam(value = "Updated user object", required = true) User user) {
@@ -112,7 +110,7 @@ public class UserResource {
             position = 5)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid username supplied"),
-            @ApiResponse(code = 404, message = "User not found")})
+            @ApiResponse(code = 404, message = "User not found") })
     public Response deleteUser(
             @ApiParam(value = "The name that needs to be deleted", required = true) @PathParam("username") String username) {
         userData.removeUser(username);
@@ -126,7 +124,7 @@ public class UserResource {
             position = 0)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = "Invalid username supplied"),
-            @ApiResponse(code = 404, message = "User not found")})
+            @ApiResponse(code = 404, message = "User not found") })
     public Response getUserByName(
             @ApiParam(value = "The name that needs to be fetched. Use user1 for testing. ", required = true) @PathParam("username") String username)
             throws ApiException {
@@ -143,7 +141,7 @@ public class UserResource {
     @ApiOperation(value = "Logs user into the system",
             response = String.class,
             position = 6)
-    @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid username/password supplied")})
+    @ApiResponses(value = { @ApiResponse(code = 400, message = "Invalid username/password supplied") })
     public Response loginUser(
             @ApiParam(value = "The user name for login", required = true) @QueryParam("username") String username,
             @ApiParam(value = "The password for login in clear text", required = true) @QueryParam("password") String password) {


### PR DESCRIPTION
This is an attempt to port this fix from swagger-core:
https://github.com/swagger-api/swagger-core/pull/1119

This way, when an API function returns, for example, a List<Person>, the
output will be docmented as a list of Persons rather than a list of
Objects.